### PR TITLE
:art: Clean up and refactor to remove @codingStandardsIgnore annotation

### DIFF
--- a/codor.xml
+++ b/codor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Project">
+    <description>Project Coding Standard</description>
+
+    <rule ref="src/Codor/ruleset.xml"/>
+</ruleset>

--- a/src/Codor/Sniffs/Files/IndentationLevelSniff.php
+++ b/src/Codor/Sniffs/Files/IndentationLevelSniff.php
@@ -79,9 +79,9 @@ class IndentationLevelSniff implements PHP_CodeSniffer_Sniff
 
     /**
      * Remove the bodies of given token type from the scope.
-     * @param  array  $scope The tokens in a scope
-     * @param  string $type  The type of token to remove from the scope
-     * @return array  $scope The tokens scope without the removed tokens
+     * @param  array  $scope The tokens in a scope.
+     * @param  string $type  The type of token to remove from the scope.
+     * @return array  $scope The tokens scope without the removed tokens.
      */
     protected function removeTokenScopes(array $scope, $type)
     {

--- a/src/Codor/Sniffs/Files/IndentationLevelSniff.php
+++ b/src/Codor/Sniffs/Files/IndentationLevelSniff.php
@@ -79,9 +79,9 @@ class IndentationLevelSniff implements PHP_CodeSniffer_Sniff
 
     /**
      * Remove the bodies of given token type from the scope.
-     * @param array $scope
-     * @param string $type
-     * @return array $scope
+     * @param  array  $scope
+     * @param  string $type
+     * @return array  $scope
      */
     protected function removeTokenScopes(array $scope, $type)
     {

--- a/src/Codor/Sniffs/Files/IndentationLevelSniff.php
+++ b/src/Codor/Sniffs/Files/IndentationLevelSniff.php
@@ -79,9 +79,9 @@ class IndentationLevelSniff implements PHP_CodeSniffer_Sniff
 
     /**
      * Remove the bodies of given token type from the scope.
-     * @param  array  $scope
-     * @param  string $type
-     * @return array  $scope
+     * @param  array  $scope The tokens in a scope
+     * @param  string $type  The type of token to remove from the scope
+     * @return array  $scope The tokens scope without the removed tokens
      */
     protected function removeTokenScopes(array $scope, $type)
     {

--- a/tests/CodeSnifferRunner.php
+++ b/tests/CodeSnifferRunner.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Tests;
 
-use PHP_CodeSniffer;
 use Codor\Tests\Wrappers\Results as ResultsWrapper;
+use PHP_CodeSniffer;
 
 class CodeSnifferRunner
 {
@@ -43,7 +43,7 @@ class CodeSnifferRunner
     /**
      * Sets the sniff we will test.
      * @param string $sniff The sniff to test.
-     * @return this
+     * @return CodeSnifferRunner
      */
     public function setSniff($sniff)
     {
@@ -66,7 +66,7 @@ class CodeSnifferRunner
      * Sets the file to run the sniffer on then
      * calls the run method to run the sniffer.
      * @param  string $file Filename.
-     * @return PHP_CodeSniffer_File Sniffer Results.
+     * @return ResultsWrapper Sniffer Results.
      */
     public function sniff($file)
     {
@@ -77,11 +77,12 @@ class CodeSnifferRunner
 
     /**
      * Runs the actual sniffer on the file.
-     * @return PHP_CodeSniffer_File Sniffer Results.
+     * @return ResultsWrapper Sniffer Results.
      */
     protected function run()
     {
         $this->codeSniffer->initStandard(__DIR__.'/../src/Codor', [$this->sniff]);
+
         return new ResultsWrapper($this->codeSniffer->processFile($this->filePath));
     }
 }

--- a/tests/Sniffs/Files/IndentationLevelSniffTest.php
+++ b/tests/Sniffs/Files/IndentationLevelSniffTest.php
@@ -67,11 +67,11 @@ class IndentationLevelSniffTest extends BaseTestCase
         $this->assertEquals(0, $results->getWarningCount());
 
         $errorMessages = $results->getAllErrorMessages();
-        $this->assertAllEqual('2 indenation levels found. Maximum of 1 indenation levels allowed.', $errorMessages);
+        $this->assertAllEqual('2 indentation levels found. Maximum of 1 indentation levels allowed.', $errorMessages);
     }
 
     /** @test */
-    public function a_method_with_no_code_produces_no_erorrs_or_warnings()
+    public function a_method_with_no_code_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('MethodWithNoCode.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -79,7 +79,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_method_with_no_indentation_produces_no_erorrs_or_warnings()
+    public function a_method_with_no_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('MethodWithNoIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -87,7 +87,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_method_with_one_level_of_indentation_produces_no_erorrs_or_warnings()
+    public function a_method_with_one_level_of_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('MethodWithOneIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -102,11 +102,11 @@ class IndentationLevelSniffTest extends BaseTestCase
         $this->assertEquals(0, $results->getWarningCount());
 
         $errorMessages = $results->getAllErrorMessages();
-        $this->assertAllEqual('2 indenation levels found. Maximum of 1 indenation levels allowed.', $errorMessages);
+        $this->assertAllEqual('2 indentation levels found. Maximum of 1 indentation levels allowed.', $errorMessages);
     }
 
     /** @test */
-    public function a_closure_with_code_produces_no_erorrs_or_warnings()
+    public function a_closure_with_code_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('ClosureWithNoCode.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -114,7 +114,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_closure_with_no_indentation_produces_no_erorrs_or_warnings()
+    public function a_closure_with_no_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('ClosureWithNoIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -122,7 +122,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_closure_with_one_level_of_indentation_produces_no_erorrs_or_warnings()
+    public function a_closure_with_one_level_of_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('ClosureWithOneIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -137,11 +137,11 @@ class IndentationLevelSniffTest extends BaseTestCase
         $this->assertEquals(0, $results->getWarningCount());
 
         $errorMessages = $results->getAllErrorMessages();
-        $this->assertAllEqual('2 indenation levels found. Maximum of 1 indenation levels allowed.', $errorMessages);
+        $this->assertAllEqual('2 indentation levels found. Maximum of 1 indentation levels allowed.', $errorMessages);
     }
 
     /** @test */
-    public function a_switch_with_no_code_produces_no_erorrs_or_warnings()
+    public function a_switch_with_no_code_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementWithNoCode.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -149,7 +149,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_switch_with_no_indentation_produces_no_erorrs_or_warnings()
+    public function a_switch_with_no_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementWithNoIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -157,7 +157,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_switch_with_one_level_of_indentation_produces_no_erorrs_or_warnings()
+    public function a_switch_with_one_level_of_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementWithOneIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -165,17 +165,17 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_switch_with_two_levels_of_indentation_produces_no_erorrs_or_warnings()
+    public function a_switch_with_two_levels_of_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementWithTwoIndentation.inc');
         $this->assertEquals(1, $results->getErrorCount());
         $this->assertEquals(0, $results->getWarningCount());
         $errorMessages = $results->getAllErrorMessages();
-        $this->assertAllEqual('2 indenation levels found. Maximum of 1 indenation levels allowed.', $errorMessages);
+        $this->assertAllEqual('2 indentation levels found. Maximum of 1 indentation levels allowed.', $errorMessages);
     }
 
     /** @test */
-    public function a_switch_in_a_function_with_no_code_produces_no_erorrs_or_warnings()
+    public function a_switch_in_a_function_with_no_code_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementInFunctionWithNoCode.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -183,7 +183,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_switch_in_a_function_with_no_indentation_produces_no_erorrs_or_warnings()
+    public function a_switch_in_a_function_with_no_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementInFunctionWithNoIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -191,7 +191,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_switch_in_a_function_with_one_level_of_indentation_produces_no_erorrs_or_warnings()
+    public function a_switch_in_a_function_with_one_level_of_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementInFunctionWithOneIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -205,11 +205,11 @@ class IndentationLevelSniffTest extends BaseTestCase
         $this->assertEquals(1, $results->getErrorCount());
         $this->assertEquals(0, $results->getWarningCount());
         $errorMessages = $results->getAllErrorMessages();
-        $this->assertAllEqual('2 indenation levels found. Maximum of 1 indenation levels allowed.', $errorMessages);
+        $this->assertAllEqual('2 indentation levels found. Maximum of 1 indentation levels allowed.', $errorMessages);
     }
 
     /** @test */
-    public function a_switch_in_a_method_with_no_code_produces_no_erorrs_or_warnings()
+    public function a_switch_in_a_method_with_no_code_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementInMethodWithNoCode.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -217,7 +217,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_switch_in_a_method_with_no_indentation_produces_no_erorrs_or_warnings()
+    public function a_switch_in_a_method_with_no_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementInMethodWithNoIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -225,7 +225,7 @@ class IndentationLevelSniffTest extends BaseTestCase
     }
 
     /** @test */
-    public function a_switch_in_a_method_with_one_level_of_indentation_produces_no_erorrs_or_warnings()
+    public function a_switch_in_a_method_with_one_level_of_indentation_produces_no_errors_or_warnings()
     {
         $results = $this->runner->sniff('SwitchStatementInMethodWithOneIndentation.inc');
         $this->assertEquals(0, $results->getErrorCount());
@@ -238,8 +238,9 @@ class IndentationLevelSniffTest extends BaseTestCase
         $results = $this->runner->sniff('SwitchStatementInMethodWithTwoIndentation.inc');
         $this->assertEquals(1, $results->getErrorCount());
         $this->assertEquals(0, $results->getWarningCount());
+
         $errorMessages = $results->getAllErrorMessages();
-        $this->assertAllEqual('2 indenation levels found. Maximum of 1 indenation levels allowed.', $errorMessages);
+        $this->assertAllEqual('2 indentation levels found. Maximum of 1 indentation levels allowed.', $errorMessages);
     }
 
     /** @test */


### PR DESCRIPTION
I noticed you had to ignore a part of the IndentationLevelSniff, so I took it upon me to refactor it a bit to get rid of the annotation.

I hope you're not unaccustomed with some functional programming :sweat_smile: