### PR TITLE
Try catch

### DIFF
--- a/tests/Sniffs/Files/Assets/IndentationLevelSniff/TryCatchWithIfInCatch.inc
+++ b/tests/Sniffs/Files/Assets/IndentationLevelSniff/TryCatchWithIfInCatch.inc
@@ -1,10 +1,16 @@
 <?php
 
-try {
-    $this->response = $this->guzzle->request(...);
-    // etc..
-} catch (\GuzzleHttp\Exception\ClientException $e) {
-    if ($e->getResponse()->getStatusCode() == 404) {
-        throw VacancyIsClosed::forId($vacancyId);
+class TryCatchWithIfInCatch
+{
+    public function doSomething()
+    {
+        try {
+            $this->response = $this->guzzle->request($method, $uri, $options);
+            // etc..
+        } catch (\GuzzleHttp\Exception\ClientException $e) {
+            if ($e->getResponse()->getStatusCode() == 404) {
+                throw VacancyIsClosed::forId($vacancyId);
+            }
+        }
     }
 }

--- a/tests/Sniffs/Files/Assets/IndentationLevelSniff/TryWithTwoIndentations.inc
+++ b/tests/Sniffs/Files/Assets/IndentationLevelSniff/TryWithTwoIndentations.inc
@@ -1,12 +1,14 @@
 <?php
 
-class TryCatchWithIfInTry
+class TryWithTwoIndentations
 {
     public function doSomething($event)
     {
         try {
-            if ($this->eventShouldBeCollected($event)) {
-                $this->collectEvent($event);
+            foreach (range(1, 5) as $id) {
+                if ($id > 2) {
+                    $this->fireTheAlarms($event);
+                }
             }
 
             $this->fire($event);

--- a/tests/Sniffs/Files/Assets/IndentationLevelSniff/TwoIndentationsAfterTry.inc
+++ b/tests/Sniffs/Files/Assets/IndentationLevelSniff/TwoIndentationsAfterTry.inc
@@ -1,6 +1,6 @@
 <?php
 
-class TryCatchWithIfInTry
+class TwoIndentationsAfterTry
 {
     public function doSomething($event)
     {
@@ -12,6 +12,12 @@ class TryCatchWithIfInTry
             $this->fire($event);
         } catch (\Exception $e) {
             $this->log($e);
+        }
+
+        foreach (range(1, 5) as $id) {
+            if ($id > 2) {
+                $this->fireTheAlarms($event);
+            }
         }
     }
 }

--- a/tests/Sniffs/Files/IndentationLevelSniffTest.php
+++ b/tests/Sniffs/Files/IndentationLevelSniffTest.php
@@ -258,4 +258,20 @@ class IndentationLevelSniffTest extends BaseTestCase
         $this->assertEquals(0, $results->getErrorCount());
         $this->assertEquals(0, $results->getWarningCount());
     }
+
+    /** @test */
+    public function a_try_catch_with_two_indentations_should_produce_an_error()
+    {
+        $results = $this->runner->sniff('TryWithTwoIndentations.inc');
+        $this->assertEquals(1, $results->getErrorCount());
+        $this->assertEquals(0, $results->getWarningCount());
+    }
+
+    /** @test */
+    public function two_indentation_outside_try_catch_should_produce_an_error()
+    {
+        $results = $this->runner->sniff('TwoIndentationsAfterTry.inc');
+        $this->assertEquals(1, $results->getErrorCount());
+        $this->assertEquals(0, $results->getWarningCount());
+    }
 }


### PR DESCRIPTION
Here's the PR that fixes the issue with the indentation inside try-catch blocks.

I had to expand the test code samples to show the same errors I found in my project.
I also added two more test samples to prove my change doesn't break any other situations.

