### PR TITLE
Update version of phpcs up to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.4",
         "phpmd/phpmd": "^2.6",
         "phploc/phploc": "^4.0",
         "sebastian/phpcpd": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Custom PHPCS sniffs to find Code Smells.",
     "require": {
         "php": ">=7.0.0",
-        "squizlabs/php_codesniffer": "^2.8.1"
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "license": "MIT",
     "authors": [
@@ -19,15 +19,18 @@
     "autoload-dev": {
         "psr-4": {
             "Codor\\Tests\\": "tests"
-        }
+        },
+        "classmap": [
+            "vendor/squizlabs/php_codesniffer"
+        ]
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",
-        "phpmd/phpmd": "^2.5",
-        "phploc/phploc": "^3.0",
-        "sebastian/phpcpd": "^2.0",
+        "phpmd/phpmd": "^2.6",
+        "phploc/phploc": "^4.0",
+        "sebastian/phpcpd": "^3.0",
         "sensiolabs/security-checker": "^4.0",
-        "slevomat/coding-standard": "^2.0",
+        "slevomat/coding-standard": "^4.0",
         "jakub-onderka/php-console-highlighter": "^0.3.2",
         "jakub-onderka/php-parallel-lint": "^0.9.2",
         "larapack/dd": "^1.1",

--- a/src/Codor/Sniffs/Classes/ClassLengthSniff.php
+++ b/src/Codor/Sniffs/Classes/ClassLengthSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Classes;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class ClassLengthSniff implements PHP_CodeSniffer_Sniff
 {
@@ -43,7 +43,7 @@ class ClassLengthSniff implements PHP_CodeSniffer_Sniff
         $length = $closedParenthesis['line'] - $openParenthesis['line'];
 
         if ($length > $this->maxLength) {
-            $phpcsFile->addError("Class is {$length} lines. Must be {$this->maxLength} lines or fewer.", $stackPtr);
+            $phpcsFile->addError("Class is {$length} lines. Must be {$this->maxLength} lines or fewer.", $stackPtr, __CLASS__);
         }
     }
 }

--- a/src/Codor/Sniffs/Classes/ConstructorLoopSniff.php
+++ b/src/Codor/Sniffs/Classes/ConstructorLoopSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Classes;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class ConstructorLoopSniff implements PHP_CodeSniffer_Sniff
 {
@@ -48,7 +48,7 @@ class ConstructorLoopSniff implements PHP_CodeSniffer_Sniff
 
         for ($index=$token['scope_opener']; $index <= $token['scope_closer']; $index++) {
             if (in_array($tokens[$index]['type'], $this->loops)) {
-                $phpcsFile->addError("Class constructor cannot contain a loop.", $stackPtr);
+                $phpcsFile->addError("Class constructor cannot contain a loop.", $stackPtr, __CLASS__);
                 continue;
             }
         }

--- a/src/Codor/Sniffs/Classes/ExtendsSniff.php
+++ b/src/Codor/Sniffs/Classes/ExtendsSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Classes;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class ExtendsSniff implements PHP_CodeSniffer_Sniff
 {
@@ -50,6 +50,6 @@ class ExtendsSniff implements PHP_CodeSniffer_Sniff
             return;
         }
         $warning = "Class extends another class - consider composition over inheritance.";
-        $this->phpcsFile->addWarning($warning, $token['line']);
+        $this->phpcsFile->addWarning($warning, $token['line'], __CLASS__);
     }
 }

--- a/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
+++ b/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Classes;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 /**
  * @SuppressWarnings(PHPMD.LongVariable)
@@ -133,7 +133,7 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
     {
         $methodName = $token['content'];
         $line = $token['line'];
-        $phpcsFile->addError("Final Class contains a protected method {$methodName} - should be private.", $line);
+        $phpcsFile->addError("Final Class contains a protected method {$methodName} - should be private.", $line, __CLASS__);
     }
 
     /**
@@ -146,6 +146,6 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
     {
         $variableName = $token['content'];
         $line = $token['line'];
-        $phpcsFile->addError("Final Class contains a protected variable {$variableName} - should be private.", $line);
+        $phpcsFile->addError("Final Class contains a protected variable {$variableName} - should be private.", $line, __CLASS__);
     }
 }

--- a/src/Codor/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/src/Codor/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Classes;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class PropertyDeclarationSniff implements PHP_CodeSniffer_Sniff
 {
@@ -152,9 +152,9 @@ class PropertyDeclarationSniff implements PHP_CodeSniffer_Sniff
     protected function handleError($undeclaredVariable, $phpcsFile, $index)
     {
         if ($this->isExtendedClass) {
-            $phpcsFile->addWarning("Class contains undeclared property {$undeclaredVariable}.", $index);
+            $phpcsFile->addWarning("Class contains undeclared property {$undeclaredVariable}.", $index, __CLASS__);
             return;
         }
-        $phpcsFile->addError("Class contains undeclared property {$undeclaredVariable}.", $index);
+        $phpcsFile->addError("Class contains undeclared property {$undeclaredVariable}.", $index, __CLASS__);
     }
 }

--- a/src/Codor/Sniffs/ControlStructures/NestedIfSniff.php
+++ b/src/Codor/Sniffs/ControlStructures/NestedIfSniff.php
@@ -2,10 +2,10 @@
 
 namespace Codor\Sniffs\ControlStructures;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff;
 
-class NestedIfSniff implements PHP_CodeSniffer_Sniff
+class NestedIfSniff implements Sniff
 {
 
     /**
@@ -67,7 +67,7 @@ class NestedIfSniff implements PHP_CodeSniffer_Sniff
             return;
         }
 
-        $this->phpcsFile->addError('Nested if statement found.', $stackPtr);
+        $this->phpcsFile->addError('Nested if statement found.', $stackPtr, __CLASS__);
         $this->errorStack[] = $stackPtr;
     }
 

--- a/src/Codor/Sniffs/ControlStructures/NoElseSniff.php
+++ b/src/Codor/Sniffs/ControlStructures/NoElseSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\ControlStructures;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 /**
  * Do not use "else" or "elseif".
@@ -30,6 +30,6 @@ class NoElseSniff implements PHP_CodeSniffer_Sniff
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
-        $phpcsFile->addError('Do not use "else" or "elseif"', $stackPtr);
+        $phpcsFile->addError('Do not use "else" or "elseif"', $stackPtr,  __CLASS__);
     }
 }

--- a/src/Codor/Sniffs/Files/FunctionLengthSniff.php
+++ b/src/Codor/Sniffs/Files/FunctionLengthSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Files;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class FunctionLengthSniff implements PHP_CodeSniffer_Sniff
 {

--- a/src/Codor/Sniffs/Files/FunctionNameContainsAndOrSniff.php
+++ b/src/Codor/Sniffs/Files/FunctionNameContainsAndOrSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Files;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class FunctionNameContainsAndOrSniff implements PHP_CodeSniffer_Sniff
 {
@@ -45,7 +45,7 @@ class FunctionNameContainsAndOrSniff implements PHP_CodeSniffer_Sniff
             return;
         }
 
-        $phpcsFile->addError($this->getErrorMessage(), $stackPtr);
+        $phpcsFile->addError($this->getErrorMessage(), $stackPtr, __CLASS__);
     }
 
     /**

--- a/src/Codor/Sniffs/Files/FunctionParameterSniff.php
+++ b/src/Codor/Sniffs/Files/FunctionParameterSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Files;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class FunctionParameterSniff implements PHP_CodeSniffer_Sniff
 {
@@ -44,11 +44,11 @@ class FunctionParameterSniff implements PHP_CodeSniffer_Sniff
         }
 
         if ($numberOfParameters > $this->maxParameters) {
-            $phpcsFile->addError("Function has more than {$this->maxParameters} parameters. Please reduce.", $stackPtr);
+            $phpcsFile->addError("Function has more than {$this->maxParameters} parameters. Please reduce.", $stackPtr, __CLASS__ . 'MoreThan');
         }
 
         if ($numberOfParameters == $this->maxParameters) {
-            $phpcsFile->addWarning("Function has {$this->maxParameters} parameters.", $stackPtr);
+            $phpcsFile->addWarning("Function has {$this->maxParameters} parameters.", $stackPtr, __CLASS__ . 'hasMax');
         }
     }
 }

--- a/src/Codor/Sniffs/Files/IndentationLevelSniff.php
+++ b/src/Codor/Sniffs/Files/IndentationLevelSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Files;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class IndentationLevelSniff implements PHP_CodeSniffer_Sniff
 {
@@ -60,7 +60,7 @@ class IndentationLevelSniff implements PHP_CodeSniffer_Sniff
             return;
         }
 
-        $phpcsFile->addError($this->getErrorMessage(), $stackPtr);
+        $phpcsFile->addError($this->getErrorMessage(), $stackPtr, __CLASS__);
     }
 
     /**

--- a/src/Codor/Sniffs/Files/MethodFlagParameterSniff.php
+++ b/src/Codor/Sniffs/Files/MethodFlagParameterSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Files;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class MethodFlagParameterSniff implements PHP_CodeSniffer_Sniff
 {
@@ -41,7 +41,7 @@ class MethodFlagParameterSniff implements PHP_CodeSniffer_Sniff
 
         for ($index=$openParenIndex+1; $index <= $closedParenIndex; $index++) {
             if (in_array($tokens[$index]['type'], $this->booleans)) {
-                $phpcsFile->addError("Function/method contains a flag parameter.", $stackPtr);
+                $phpcsFile->addError("Function/method contains a flag parameter.", $stackPtr, __CLASS__);
                 continue;
             }
         }

--- a/src/Codor/Sniffs/Files/ReturnNullSniff.php
+++ b/src/Codor/Sniffs/Files/ReturnNullSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Files;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class ReturnNullSniff implements PHP_CodeSniffer_Sniff
 {
@@ -38,7 +38,7 @@ class ReturnNullSniff implements PHP_CodeSniffer_Sniff
 
         if ($scope[$returnValueIndex]['type'] === 'T_NULL') {
             $error = "Return null value found.";
-            $phpcsFile->addError($error, $returnValueIndex);
+            $phpcsFile->addError($error, $returnValueIndex, __CLASS__);
         }
     }
 }

--- a/src/Codor/Sniffs/Syntax/LinesAfterMethodSniff.php
+++ b/src/Codor/Sniffs/Syntax/LinesAfterMethodSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Syntax;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class LinesAfterMethodSniff implements PHP_CodeSniffer_Sniff
 {
@@ -43,7 +43,7 @@ class LinesAfterMethodSniff implements PHP_CodeSniffer_Sniff
         $linesBetween = $nextCodeLine - $tokens[$endOfMethodIndex]['line'] - 1;
 
         if ($linesBetween > 1) {
-            $phpcsFile->addError("No more than 1 line after a method/function is allowed.", $stackPtr);
+            $phpcsFile->addError("No more than 1 line after a method/function is allowed.", $stackPtr, __CLASS__);
         }
     }
 }

--- a/src/Codor/Sniffs/Syntax/NullCoalescingSniff.php
+++ b/src/Codor/Sniffs/Syntax/NullCoalescingSniff.php
@@ -2,8 +2,8 @@
 
 namespace Codor\Sniffs\Syntax;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
 
 class NullCoalescingSniff implements PHP_CodeSniffer_Sniff
 {
@@ -37,7 +37,7 @@ class NullCoalescingSniff implements PHP_CodeSniffer_Sniff
         $index           = $stackPtr;
 
         if ($this->couldBeNullCoalescing($tokens, $index)) {
-            $phpcsFile->addError("Ternery found where Null Coalescing operator will work.", $stackPtr);
+            $phpcsFile->addError("Ternery found where Null Coalescing operator will work.", $stackPtr, __CLASS__);
         }
     }
 

--- a/src/Codor/Sniffs/TypeHints/MixedReturnTypeSniff.php
+++ b/src/Codor/Sniffs/TypeHints/MixedReturnTypeSniff.php
@@ -2,9 +2,9 @@
 
 namespace Codor\Sniffs\TypeHints;
 
-use PHP_CodeSniffer_Sniff;
-use PHP_CodeSniffer_File;
-use PHP_CodeSniffer_Tokens;
+use PHP_CodeSniffer\Sniffs\Sniff as PHP_CodeSniffer_Sniff;
+use PHP_CodeSniffer\Files\File as PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Util\Tokens as PHP_CodeSniffer_Tokens;
 
 class MixedReturnTypeSniff implements PHP_CodeSniffer_Sniff
 {
@@ -71,7 +71,7 @@ class MixedReturnTypeSniff implements PHP_CodeSniffer_Sniff
         // Check return type (can be multiple, separated by '|').
         foreach (explode('|', $returnType) as $typeName) {
             if ($typeName === self::MIXED_TYPE) {
-                $phpcsFile->addError('Function return type contains mixed', $commentStart);
+                $phpcsFile->addError('Function return type contains mixed', $commentStart, __CLASS__);
             }
         }
     }

--- a/tests/Sniffs/ControlStructures/NoElseSniffTest.php
+++ b/tests/Sniffs/ControlStructures/NoElseSniffTest.php
@@ -8,9 +8,9 @@ use Codor\Tests\BaseTestCase;
 class NoElseSniffTest extends BaseTestCase
 {
 
-    public function setup()
+    public function setUp()
     {
-        parent::setup();
+        parent::setUp();
 
         $this->runner->setSniff('Codor.ControlStructures.NoElse')->setFolder(__DIR__.'/Assets/NoElseSniff/');
     }
@@ -18,7 +18,8 @@ class NoElseSniffTest extends BaseTestCase
     public function testSniff()
     {
         $results = $this->runner->sniff('NoElseSniff.inc');
-        $this->assertSame(5, $results->getErrorCount());
+
+	    $this->assertSame(5, $results->getErrorCount());
         $this->assertSame(0, $results->getWarningCount());
 
         $errorMessages = $results->getAllErrorMessages();

--- a/tests/Wrappers/Results.php
+++ b/tests/Wrappers/Results.php
@@ -2,21 +2,21 @@
 
 namespace Codor\Tests\Wrappers;
 
-use PHP_CodeSniffer_File;
+use PHP_CodeSniffer\Files\File;
 
 class Results
 {
     /**
      * This is the class that we're wrapping up.
-     * @var PHP_CodeSniffer_File
+     * @var File
      */
     protected $wrappedClass;
 
     /**
      * Class constructor.
-     * @param PHP_CodeSniffer_File $wrappedClass Class we're wrapping up.
+     * @param File $wrappedClass Class we're wrapping up.
      */
-    public function __construct(PHP_CodeSniffer_File $wrappedClass)
+    public function __construct(File $wrappedClass)
     {
         $this->wrappedClass = $wrappedClass;
     }


### PR DESCRIPTION
## What's patched
- Rename CS classnames @ Coder sniffs classes (namespace added)
- Add third required param to `addError()` and `addWarning()` methods @ Coder sniffs
- Refactor `CodeSnifferRunner` class for Codor tests (create and run) 

## Issues
- added `autoload-dev` classmap for code_sniffer 
(because of did not found it at standart `autoload.php` file)
- Updates for CodeSnifferRunner probably looks dirty, but did have good interfaces in short time
 
## Result
CS version updated up to ^3.0 with test covers