### PR TITLE
handleProtectedVariableToken needs 2 parameters

### DIFF
--- a/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
+++ b/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
@@ -41,10 +41,12 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
      * Processes the tokens that this sniff is interested in.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
+     * @param int                  $stackPtr  The position in the stack where
+     *                                        the token was found.
      * @return void
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile)
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {
         $this->classIsMarkedFinal = false;
         $this->protectedMethodTokens = [];

--- a/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
+++ b/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
@@ -109,10 +109,9 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
     /**
      * Handle any errors.
      * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-     * @param int                  $stackPtr  The position in the stack where.
      * @return void
      */
-    protected function handleErrors($phpcsFile, $stackPtr)
+    protected function handleErrors($phpcsFile)
     {
         foreach ($this->protectedMethodTokens as $protectedMethodToken) {
             $this->handleProtectedMethodToken($protectedMethodToken, $phpcsFile);

--- a/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
+++ b/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
@@ -44,7 +44,8 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
      * @param int                  $stackPtr  The position in the stack where
      *                                        the token was found.
      * @return void
-     * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+     * @SuppressWarnings(PHPMD.UnusedLocalVariable,)
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
     {

--- a/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
+++ b/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
@@ -119,7 +119,7 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
         }
 
         foreach ($this->protectedVariableTokens as $protectedVariableToken) {
-            $this->handleProtectedVariableToken($protectedVariableToken, $phpcsFile, $stackPtr);
+            $this->handleProtectedVariableToken($protectedVariableToken, $phpcsFile);
         }
     }
 

--- a/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
+++ b/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
@@ -41,12 +41,10 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
      * Processes the tokens that this sniff is interested in.
      *
      * @param PHP_CodeSniffer_File $phpcsFile The file where the token was found.
-     * @param int                  $stackPtr  The position in the stack where
-     *                                        the token was found.
      * @return void
      * @SuppressWarnings(PHPMD.UnusedLocalVariable)
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(PHP_CodeSniffer_File $phpcsFile)
     {
         $this->classIsMarkedFinal = false;
         $this->protectedMethodTokens = [];

--- a/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
+++ b/src/Codor/Sniffs/Classes/FinalPrivateSniff.php
@@ -58,7 +58,7 @@ class FinalPrivateSniff implements PHP_CodeSniffer_Sniff
             $this->handleToken($tokens, $index);
         }
 
-        $this->handleErrors($phpcsFile, $stackPtr);
+        $this->handleErrors($phpcsFile);
     }
 
     /**


### PR DESCRIPTION
discovered by @phpstan

phpmd now noticed the unused `$stackPtr`